### PR TITLE
SL-38483: Fix creating a client when there is no live request

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -42,7 +42,7 @@ module OmniAuth
         options.client_id = provider.client_id
         options.client_secret = provider.client_secret
         options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
-        options.authorize_params.prompt = request.params['prompt'] if request.params['prompt']
+        options.authorize_params.prompt = request.params['prompt'] if !request.env.nil? && request.params['prompt']
 
         super
       end

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -53,6 +53,22 @@ describe OmniAuth::Strategies::AzureOauth2 do
           subject.client
           expect(subject.authorize_params[:domain_hint]).to eql('hint')
         end
+
+        it 'should set prompt' do
+          request.params.merge!('prompt' => 'login')
+          allow(subject).to receive(:request) { request }
+          subject.client
+          expect(subject.authorize_params[:prompt]).to eql('login')
+        end
+      end
+
+      context 'when env is nil' do
+        let(:request) { double('Request', :params => {}, :cookies => {}, :env => nil) }
+
+        it 'creates a client successfully' do
+          allow(subject).to receive(:request) { request }
+          subject.client
+        end
       end
     end
 

--- a/spec/omniauth/strategies/azure_oauth2_spec.rb
+++ b/spec/omniauth/strategies/azure_oauth2_spec.rb
@@ -62,8 +62,8 @@ describe OmniAuth::Strategies::AzureOauth2 do
         end
       end
 
-      context 'when env is nil' do
-        let(:request) { double('Request', :params => {}, :cookies => {}, :env => nil) }
+      context 'when params and env are nil' do
+        let(:request) { double('Request', :params => nil, :cookies => {}, :env => nil) }
 
         it 'creates a client successfully' do
           allow(subject).to receive(:request) { request }


### PR DESCRIPTION
During refresh tokens there are no live request and `@env` is nil in `request` and the following [line](https://github.com/kwbock/omniauth-azure-oauth2/blob/master/lib/omniauth/strategies/azure_oauth2.rb#L45) throws 500 error - `undefined method [] for NilClass`